### PR TITLE
Lab7 do oceny

### DIFF
--- a/oolab/src/main/java/agh/ics/oop/Simulation.java
+++ b/oolab/src/main/java/agh/ics/oop/Simulation.java
@@ -5,7 +5,7 @@ import agh.ics.oop.model.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Simulation {
+public class Simulation implements Runnable{
 
     private final List <Animal> animalsList;
     private final List <MoveDirection> movesList;
@@ -29,6 +29,7 @@ public class Simulation {
         }
     }
 
+    @Override
     public void run() {
         int animalIx = 0;
         for (MoveDirection move : movesList) {

--- a/oolab/src/main/java/agh/ics/oop/SimulationEngine.java
+++ b/oolab/src/main/java/agh/ics/oop/SimulationEngine.java
@@ -22,16 +22,8 @@ public class SimulationEngine {
         for (Simulation sim : simulationList) sim.run();
     }
 
-    /*
-        public void runAsync() {
-            for (Thread thread : simulationThreads) thread.start();
-        }
-    */
-
     public void runAsync() {
         for (Thread thread : simulationThreads) thread.start();
-
-        awaitSimulationsEnd();
     }
 
     public void awaitSimulationsEnd() {
@@ -53,7 +45,5 @@ public class SimulationEngine {
 
     public void runAsyncInThreadPool() {
         for (Simulation sim : simulationList) executorService.submit(sim);
-
-        awaitSimulationsEnd();
     }
 }

--- a/oolab/src/main/java/agh/ics/oop/SimulationEngine.java
+++ b/oolab/src/main/java/agh/ics/oop/SimulationEngine.java
@@ -1,0 +1,59 @@
+package agh.ics.oop;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class SimulationEngine {
+
+    private final List <Simulation> simulationList;
+    private final List <Thread> simulationThreads = new ArrayList<>();
+    private final ExecutorService executorService = Executors.newFixedThreadPool(4);
+    public SimulationEngine(List<Simulation> simulationList) {
+        this.simulationList = simulationList;
+
+        for (Simulation sim : simulationList) simulationThreads.add(new Thread(sim));
+    }
+
+    public void runSync() {
+        for (Simulation sim : simulationList) sim.run();
+    }
+
+    /*
+        public void runAsync() {
+            for (Thread thread : simulationThreads) thread.start();
+        }
+    */
+
+    public void runAsync() {
+        for (Thread thread : simulationThreads) thread.start();
+
+        awaitSimulationsEnd();
+    }
+
+    public void awaitSimulationsEnd() {
+        for (Thread thread : simulationThreads) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        executorService.shutdown();
+        try {
+            executorService.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void runAsyncInThreadPool() {
+        for (Simulation sim : simulationList) executorService.submit(sim);
+
+        awaitSimulationsEnd();
+    }
+}

--- a/oolab/src/main/java/agh/ics/oop/World.java
+++ b/oolab/src/main/java/agh/ics/oop/World.java
@@ -2,6 +2,7 @@ package agh.ics.oop;
 
 import agh.ics.oop.model.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class World {
@@ -17,11 +18,26 @@ public class World {
 
      List<Vector2d> positions = List.of(new Vector2d(2,2), new Vector2d(3,4));
 
-     var map = new GrassField(10, 1);
-     map.addListener(listener);
+     List <Simulation> simulations = new ArrayList<>();
 
-     Simulation simulation = new Simulation(positions, directions, map);
-     simulation.run();
+     for (int i = 1; i <= 500; i++) {
+         var map = new RectangularMap(5, 5, i);
+         map.addListener(listener);
+         simulations.add(new Simulation(positions, directions, map));
+     }
+     for (int i = 501; i <= 1000; i++) {
+         var map = new GrassField(10, i);
+         map.addListener(listener);
+         simulations.add(new Simulation(positions, directions, map));
+     }
+
+     var simulationEngine = new SimulationEngine(simulations);
+
+     //simulationEngine.runSync();
+     //simulationEngine.runAsync();
+     simulationEngine.runAsyncInThreadPool();
+
+     System.out.println("System zakończył działanie");
  }
 
 }

--- a/oolab/src/main/java/agh/ics/oop/World.java
+++ b/oolab/src/main/java/agh/ics/oop/World.java
@@ -37,6 +37,8 @@ public class World {
      //simulationEngine.runAsync();
      simulationEngine.runAsyncInThreadPool();
 
+     simulationEngine.awaitSimulationsEnd();
+
      System.out.println("System zakończył działanie");
  }
 

--- a/oolab/src/main/java/agh/ics/oop/model/AbstractWorldMap.java
+++ b/oolab/src/main/java/agh/ics/oop/model/AbstractWorldMap.java
@@ -9,6 +9,11 @@ public abstract class AbstractWorldMap implements WorldMap {
     protected final Map<Vector2d, Animal> animalMap = new HashMap<>();
     protected List<MapChangeListener> listenersList = new ArrayList<>();
     protected Boundary bounds;
+    private final int id;
+
+    public AbstractWorldMap(int id) {
+        this.id = id;
+    }
 
 
     private void mapChanged(String message) {
@@ -78,5 +83,10 @@ public abstract class AbstractWorldMap implements WorldMap {
         var mapVisualizer = new MapVisualizer(this);
         Boundary mapBoundary = getCurrentBounds();
         return mapVisualizer.draw(mapBoundary.lowerLeftVector(), mapBoundary.upperRightVector());
+    }
+
+    @Override
+    public int getId() {
+        return id;
     }
 }

--- a/oolab/src/main/java/agh/ics/oop/model/ConsoleMapDisplay.java
+++ b/oolab/src/main/java/agh/ics/oop/model/ConsoleMapDisplay.java
@@ -2,11 +2,17 @@ package agh.ics.oop.model;
 
 public class ConsoleMapDisplay implements MapChangeListener {
     private int updates = 0;
+    /*
+        Wersja race condition różni się tylko keywordem synchronized
+        public void mapChanged(WorldMap map, String message)
+    */
     @Override
-    public void mapChanged(WorldMap map, String message) {
+    public synchronized void mapChanged(WorldMap map, String message) {
         updates++;
+        System.out.println("Map nr " + map.getId());
         System.out.println(message);
         System.out.println(map);
         System.out.println("Number of updates: " + updates);
+        System.out.println();
     }
 }

--- a/oolab/src/main/java/agh/ics/oop/model/GrassField.java
+++ b/oolab/src/main/java/agh/ics/oop/model/GrassField.java
@@ -13,7 +13,8 @@ public class GrassField extends AbstractWorldMap{
     private final Vector2d LOWER_LEFT_VECTOR = new Vector2d(Integer.MIN_VALUE, Integer.MIN_VALUE);
     private final Vector2d UPPER_RIGHT_VECTOR = new Vector2d(Integer.MAX_VALUE, Integer.MAX_VALUE);
 
-    public GrassField(int grassCount, Integer randomSeed) {
+    public GrassField(int grassCount, Integer randomSeed, int id) {
+        super(id);
         var generator = (randomSeed != null)? new Random(randomSeed) : new Random();
         int upperBound = (int)Math.ceil(Math.sqrt(grassCount * 10));
 
@@ -29,8 +30,8 @@ public class GrassField extends AbstractWorldMap{
         }
     }
 
-    public GrassField(int grassCount) {
-        this(grassCount, null);
+    public GrassField(int grassCount, int id) {
+        this(grassCount, null, id);
     }
 
     private void updateMapBound(Vector2d pos) {

--- a/oolab/src/main/java/agh/ics/oop/model/RectangularMap.java
+++ b/oolab/src/main/java/agh/ics/oop/model/RectangularMap.java
@@ -3,7 +3,8 @@ package agh.ics.oop.model;
 import agh.ics.oop.model.util.MapVisualizer;
 
 public class RectangularMap extends AbstractWorldMap{
-    public RectangularMap(int width, int height) {
+    public RectangularMap(int width, int height, int id) {
+        super(id);
         bounds = new Boundary(new Vector2d(0, 0), new Vector2d(width-1, height-1));
     }
 

--- a/oolab/src/main/java/agh/ics/oop/model/WorldMap.java
+++ b/oolab/src/main/java/agh/ics/oop/model/WorldMap.java
@@ -4,6 +4,7 @@ import agh.ics.oop.model.MoveDirection;
 import agh.ics.oop.model.Vector2d;
 
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * The interface responsible for interacting with the map of the world.
@@ -47,4 +48,6 @@ public interface WorldMap extends MoveValidator {
     Collection <WorldElement> getElements();
 
     Boundary getCurrentBounds();
+
+    int getId();
 }

--- a/oolab/src/test/java/agh/ics/oop/SimulationTest.java
+++ b/oolab/src/test/java/agh/ics/oop/SimulationTest.java
@@ -24,7 +24,7 @@ public class SimulationTest {
     void runTestBasic() {
         List<MoveDirection> directions = OptionsParser.parse(new String[]{"f", "b", "r", "l", "f", "f", "r", "r", "f", "f", "f", "f", "f", "f", "f", "f"});
         List<Vector2d> positions = List.of(new Vector2d(2, 2), new Vector2d(3, 4));
-        RectangularMap map = new RectangularMap(5, 5);
+        RectangularMap map = new RectangularMap(5, 5, 1);
         Simulation simulation = new Simulation(positions, directions, map);
         simulation.run();
 
@@ -39,7 +39,7 @@ public class SimulationTest {
     void runTestBounds() {
         List <MoveDirection> directions = OptionsParser.parse(new String[]{"f", "f", "f", "f", "f", "f"});
         List <Vector2d> positions = List.of(new Vector2d(2, 2));
-        RectangularMap map = new RectangularMap(5, 5);
+        RectangularMap map = new RectangularMap(5, 5, 1);
         Simulation simulation = new Simulation(positions, directions, map);
         simulation.run();
 
@@ -51,7 +51,7 @@ public class SimulationTest {
     void runTestBig() {
         List <MoveDirection> directions = OptionsParser.parse(new String[]{"f", "b", "l", "r", "f", "b", "l", "r", "f", "b"});
         List <Vector2d> positions = List.of(new Vector2d(2, 2), new Vector2d(0, 1), new Vector2d(1, 0), new Vector2d(3, 4), new Vector2d(3, 1));
-        RectangularMap map = new RectangularMap(5, 5);
+        RectangularMap map = new RectangularMap(5, 5, 1);
         Simulation simulation = new Simulation(positions, directions, map);
         simulation.run();
 
@@ -75,7 +75,7 @@ public class SimulationTest {
     void runTestCollisions1() {
         List <MoveDirection> directions = OptionsParser.parse(new String[]{"f", "f", "f", "f"});
         List <Vector2d> positions = List.of(new Vector2d(2, 1), new Vector2d(2, 0));
-        RectangularMap map = new RectangularMap(5, 5);
+        RectangularMap map = new RectangularMap(5, 5, 1);
         Simulation simulation = new Simulation(positions, directions, map);
         simulation.run();
 
@@ -91,7 +91,7 @@ public class SimulationTest {
     void runTestCollisions2() {
         List <MoveDirection> directions = OptionsParser.parse(new String[] {"f", "f", "f", "f"});
         List <Vector2d> positions = List.of(new Vector2d(2, 0), new Vector2d(2, 1));
-        RectangularMap map = new RectangularMap(5, 5);
+        RectangularMap map = new RectangularMap(5, 5, 1);
         Simulation simulation = new Simulation(positions, directions, map);
         simulation.run();
 

--- a/oolab/src/test/java/agh/ics/oop/model/GrassFieldTest.java
+++ b/oolab/src/test/java/agh/ics/oop/model/GrassFieldTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class GrassFieldTest {
     @Test
     void placeTest() {
-        var map = new GrassField(10, 1);
+        var map = new GrassField(10, 1, 1);
         List<Animal> animals = List.of(new Animal(new Vector2d(1, 1)), new Animal(new Vector2d(0, 0)), new Animal(new Vector2d(0, 4)));
 
         assertDoesNotThrow(() -> map.place(animals.get(0)));
@@ -31,7 +31,7 @@ public class GrassFieldTest {
 
     @Test
     void placeExceptionTest() {
-        var map = new GrassField(10, 1);
+        var map = new GrassField(10, 1, 1);
         List<Animal> animals = List.of(new Animal(new Vector2d(1, 1)), new Animal(new Vector2d(1, 1)), new Animal(new Vector2d(1, 1)));
 
         assertDoesNotThrow(() -> map.place(animals.get(0)));
@@ -45,7 +45,7 @@ public class GrassFieldTest {
 
     @Test
     void moveTest() {
-        var map = new GrassField(10, 1);
+        var map = new GrassField(10, 1, 1);
         List<Animal> animals = List.of(new Animal(new Vector2d(1, 1)), new Animal(new Vector2d(0, 0)), new Animal(new Vector2d(0, 4)));
 
         assertDoesNotThrow(() -> map.place(animals.get(0)));

--- a/oolab/src/test/java/agh/ics/oop/model/RectangularMapTest.java
+++ b/oolab/src/test/java/agh/ics/oop/model/RectangularMapTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class RectangularMapTest {
     @Test
     void placeTest() {
-        var map = new RectangularMap(4, 5);
+        var map = new RectangularMap(4, 5, 1);
         List <Animal> animals = List.of(new Animal(new Vector2d(1, 1)), new Animal(new Vector2d(0, 0)), new Animal(new Vector2d(0, 4)));
         assertDoesNotThrow(() -> map.place(animals.get(0)));
         assertDoesNotThrow(() -> map.place(animals.get(1)));
@@ -30,7 +30,7 @@ public class RectangularMapTest {
 
     @Test
     void moveTest() {
-        var map = new RectangularMap(4, 5);
+        var map = new RectangularMap(4, 5, 1);
         List <Animal> animals = List.of(new Animal(new Vector2d(1, 1)), new Animal(new Vector2d(0, 0)), new Animal(new Vector2d(0, 4)));
         assertDoesNotThrow(() -> map.place(animals.get(0)));
         assertDoesNotThrow(() -> map.place(animals.get(1)));


### PR DESCRIPTION
Dla metody runAsync mapy wypisują się w różnej kolejności, niezależnej od kolejności tworzenia wątków. 

Napis "System zakończył działanie" wyświetla się przed zakończeniem symulacji, wynika to z tego że po utworzeniu wątków metoda runAsync kończy działanie a następnie reszta programu (println w World) wykonuje się współbieżnie z symulacjami. Po dodaniu metody awaitSimulationsEnd napis pojawia się po zakończeniu wszystkich symulacji.

Licznik aktualizacji nie działa poprawnie, liczba aktualizacji jest mniejsza od faktycznego stanu. Wynika to z tego że jeśli dwa wątki w tym samym czasie będą aktualizować licznik, jeden wątek nadpisze wartość przypisaną przez drugi. Aby naprawić błąd wystarczy dodać keyword synchronized do metody wypisującej mapę aby wątki nie mogły równocześnie aktualizować stanu licznika.

Zastosowanie puli wątków jest lepszym pomysłem ponieważ 1000 wątków nie sprawi że wszystkie symulacje wykonają się na raz. ThreadPool zarządza zasobami za nas, mała liczba wątków wystarcza żeby zrównoleglić działanie programu, procesor nie musi skakać między dużą liczbą wątków i może zamiast tego wykonywać faktyczne obliczenia.